### PR TITLE
export the fwrite! macro

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,3 +1,4 @@
+#[macro_export]
 macro_rules! fast_fmt_instantiate {
     ($arg:expr) => {
         $crate::Instantiated::new($arg, &$crate::consts::DISPLAY)
@@ -10,6 +11,7 @@ macro_rules! fast_fmt_instantiate {
     };
 }
 
+#[macro_export]
 macro_rules! fwrite {
     ($writer:expr, $($args:expr),*) => {
         {


### PR DESCRIPTION
I suppose this was method to be exposed. Or is it not the preferred way to do
formatting?